### PR TITLE
Make sure state is set before calling onChange cb

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./src/');
+exports.ColorPicker = require('./src/ColorPicker');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "files": [
     "src/",
-    "assets/*.less"
+    "assets/*.less",
+    "index.js"
   ],
   "config": {
     "port": 8000

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "url": "http://github.com/react-component/react-colors-picker/issues"
   },
   "files": [
-    "lib/",
-    "assets/*.css"
+    "src/",
+    "assets/*.less"
   ],
   "config": {
     "port": 8000

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -58,13 +58,13 @@ export default class Panel extends React.Component {
     if (syncParams) {
       state.paramsHsv = hsv;
     }
-    this.setState(state);
-
-    const ret = {
-      color: this.getHexColor(),
-      alpha: this.state.alpha,
-    };
-    this.props.onChange(ret);
+    this.setState(state, () => {
+      const ret = {
+        color: this.getHexColor(),
+        alpha: this.state.alpha,
+      };
+      this.props.onChange(ret);
+    });
   }
 
   onAlphaChange(alpha) {


### PR DESCRIPTION
The onChange callback is getting called with the previous state color because `this.getHexColor()` depends on the state being updated.

I've moved this function call to the callback of this.setState to ensure that the state is set. Another solution could be to pass an optional arg into getHexColor