### PR TITLE
feat: remote store and refactor preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ color|String|#ff0000|color board current background color
 orient| String[] | ['top', 'left'] | Picker show direction of trigger
 onChange| Function | noop | when select color
 trigger|Node|`<span className='react-colorpicker-trigger'></span>`|additional trigger appended to picker
-storeMode|Boolean|true| if store color mode on localStore after color mode change
+mode|String|'RGB'| color mode, support mode 'RGB', 'HSB' or 'HSL'
 
 ### ColorPicker.Panel.props
 
@@ -70,7 +70,7 @@ style | Object | {} | root node CSS style
 onChange|Function| | when select color trigger
 onFocus|Function| | when picker focus trigger
 onBlur|Function| | when picker loose focus
-storeMode|Boolean|true| if store color mode on localStore after color mode change
+mode|String|'RGB'| color mode, support mode 'RGB', 'HSB' or 'HSL'
 
 ## License
 

--- a/assets/index/Preview.less
+++ b/assets/index/Preview.less
@@ -4,11 +4,17 @@
   overflow: hidden;
   border-radius: 2px;
   box-shadow: 0 0 2px #808080 inset;
+  background-image: url('data:image/png;base64,R0lGODdhCgAKAPAAAOXl5f///ywAAAAACgAKAEACEIQdqXt9GxyETrI279OIgwIAOw==');
+
+  span,
   input[type=color] {
+    position: absolute;
     display: block;
     height: 100%;
     width: 30px;
     border-radius: 2px;
+  }
+  input[type=color] {
     opacity: 0;
   }
 }

--- a/assets/index/Preview.less
+++ b/assets/index/Preview.less
@@ -3,12 +3,12 @@
   width: 30px;
   overflow: hidden;
   border-radius: 2px;
-  background-image: url('data:image/png;base64,R0lGODdhCgAKAPAAAOXl5f///ywAAAAACgAKAEACEIQdqXt9GxyETrI279OIgwIAOw==');
-  background-repeat: repeat;
-  span{
+  box-shadow: 0 0 2px #808080 inset;
+  input[type=color] {
     display: block;
     height: 100%;
-    box-shadow: 0 0 2px #808080 inset;
+    width: 30px;
     border-radius: 2px;
+    opacity: 0;
   }
 }

--- a/examples/panel.js
+++ b/examples/panel.js
@@ -10,7 +10,7 @@ function onChange(obj) {
 
 React.render(
   <div>
-    <ColorPickerPanel defaultColor={'#468890'} onChange={onChange}/>
+    <ColorPickerPanel defaultColor={'#468890'} onChange={onChange} mode="HSL"/>
   </div>,
   document.getElementById('__react-content')
 );

--- a/package.json
+++ b/package.json
@@ -52,10 +52,9 @@
   "dependencies": {
     "colr": "~1.2.1",
     "object-assign": "~3.0.0",
-    "rc-align": "^1.2.0",
-    "rc-animate": "^1.1.0",
-    "rc-util": "^2.0.3",
-    "store": "^1.3.17"
+    "rc-align": "~1.2.0",
+    "rc-animate": "~1.1.0",
+    "rc-util": "~2.0.3"
   },
   "precommit": [
     "lint"

--- a/src/ColorPicker.jsx
+++ b/src/ColorPicker.jsx
@@ -123,11 +123,11 @@ export default class ColorPicker extends React.Component {
     const pickerPanelElement = (<ColorPickerPanel
         ref={this.savePickerPanelRef}
         defaultColor={this.state.color}
-        storeMode={this.props.storeMode}
         alpha={this.state.alpha}
         prefixCls={this.props.prefixCls + '-panel'}
         onChange={this.onChange}
         onBlur={this.onBlur}
+        mode={this.props.mode}
       />);
 
     const orient = this.props.orient;
@@ -208,7 +208,7 @@ ColorPicker.propTypes = {
   onChange: React.PropTypes.func,
   prefixCls: React.PropTypes.string.isRequired,
   trigger: React.PropTypes.node.isRequired,
-  storeMode: React.PropTypes.boolean,
+  mode: React.PropTypes.string,
 };
 
 ColorPicker.defaultProps = {
@@ -221,5 +221,4 @@ ColorPicker.defaultProps = {
   },
   prefixCls: 'react-colorpicker',
   trigger: <span className="react-colorpicker-trigger"></span>,
-  storeMode: true,
 };

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -29,6 +29,7 @@ export default class Panel extends React.Component {
       'onAlphaChange',
       'onFocus',
       'onBlur',
+      'onSystemColorPickerOpen',
     ];
     // bind methods
     events.forEach(m => {
@@ -68,6 +69,13 @@ export default class Panel extends React.Component {
     this.props.onChange(ret);
   }
 
+  onSystemColorPickerOpen(e) {
+    // only work with broswer which support color input
+    if (e.target.type === 'color') {
+      this.systemColorPickerOpen = true;
+    }
+  }
+
   onAlphaChange(alpha) {
     if (this.props.alpha === undefined) {
       this.setState({
@@ -95,6 +103,12 @@ export default class Panel extends React.Component {
       clearTimeout(this._blurTimer);
     }
     this._blurTimer = setTimeout(()=> {
+      // if is system color picker open, then stop run blur
+      if (this.systemColorPickerOpen) {
+        this.systemColorPickerOpen = false;
+        return;
+      }
+
       this.props.onBlur();
     }, 100);
   }
@@ -142,6 +156,7 @@ export default class Panel extends React.Component {
                 rootPrefixCls={prefixCls}
                 alpha={alpha}
                 onChange={this.onChange}
+                onInputClick={this.onSystemColorPickerOpen}
                 hsv={hsv}
                 />
             </div>

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -141,6 +141,7 @@ export default class Panel extends React.Component {
               <Preview
                 rootPrefixCls={prefixCls}
                 alpha={alpha}
+                onChange={this.onChange}
                 hsv={hsv}
                 />
             </div>
@@ -152,6 +153,7 @@ export default class Panel extends React.Component {
               alpha={alpha}
               onAlphaChange={this.onAlphaChange}
               onChange={this.onChange}
+              mode={this.props.mode}
               />
           </div>
         </div>
@@ -170,7 +172,7 @@ Panel.propTypes = {
   onChange: React.PropTypes.func,
   onFocus: React.PropTypes.func,
   onBlur: React.PropTypes.func,
-  storeMode: React.PropTypes.boolean,
+  mode: React.PropTypes.string,
 };
 
 Panel.defaultProps = {
@@ -181,5 +183,4 @@ Panel.defaultProps = {
   onChange: noop,
   onFocus: noop,
   onBlur: noop,
-  storeMode: true,
 };

--- a/src/Params.jsx
+++ b/src/Params.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Colr from 'colr';
-let store;
 
 const colr = new Colr();
 const modesMap = ['RGB', 'HSB', 'HSL'];
@@ -9,21 +8,12 @@ export default class Params extends React.Component {
 
   constructor(props) {
     super(props);
-    let defaultIndex = 0;
-    if (props.storeMode) {
-      if (!store) {
-        store = require('store');
-      }
-      defaultIndex = store.get('react-colorspicker-mode') || 0;
-    }
-    this.modeIndex = defaultIndex;
-    const mode = modesMap[this.modeIndex];
 
     const color = colr.fromHsvObject(props.hsv);
 
     // 管理 input 的状态
     this.state = {
-      mode: mode,
+      mode: props.mode,
       color: color,
       hex: color.toHex().substr(1),
     };
@@ -77,13 +67,12 @@ export default class Params extends React.Component {
   }
 
   onModeChange() {
-    this.modeIndex = (this.modeIndex + 1) % modesMap.length;
+    let mode = this.state.mode;
+    const modeIndex = (modesMap.indexOf(mode) + 1) % modesMap.length;
     const state = this.state;
-    const mode = modesMap[this.modeIndex];
+
+    mode = modesMap[modeIndex];
     const colorChannel = this.getColorChannel(state.color, mode);
-    if (this.props.storeMode) {
-      store.set('react-colorspicker-mode', this.modeIndex);
-    }
     this.setState({
       mode,
       colorChannel,
@@ -236,5 +225,9 @@ Params.propTypes = {
   alpha: React.PropTypes.number,
   rootPrefixCls: React.PropTypes.string,
   onAlphaChange: React.PropTypes.func,
-  storeMode: React.PropTypes.boolean,
+  mode: React.PropTypes.oneOf(modesMap),
+};
+
+Params.defaultProps = {
+  mode: modesMap[0],
 };

--- a/src/Preview.jsx
+++ b/src/Preview.jsx
@@ -8,6 +8,7 @@ export default class Preview extends React.Component {
     const value = e.target.value;
     const color = colr.fromHex(value);
     this.props.onChange(color.toHsvObject());
+    e.stopPropagation();
   }
 
   getPrefixCls() {
@@ -18,10 +19,14 @@ export default class Preview extends React.Component {
     const prefixCls = this.getPrefixCls();
     const hex = colr.fromHsvObject(this.props.hsv).toHex();
     return (
-      <div className={prefixCls}
-        style={{backgroundColor: hex, opacity: this.props.alpha / 100}}
-      >
-        <input type="color" value={hex} onChange={this.onChange.bind(this)}/>
+      <div className={prefixCls}>
+        <span style={{backgroundColor: hex, opacity: this.props.alpha / 100}} ></span>
+        <input
+          type="color"
+          value={hex}
+          onChange={this.onChange.bind(this)}
+          onClick={this.props.onInputClick}
+        />
       </div>
     );
   }
@@ -32,4 +37,5 @@ Preview.propTypes = {
   hsv: React.PropTypes.object,
   alpha: React.PropTypes.number,
   onChange: React.PropTypes.func,
+  onInputClick: React.PropTypes.func,
 };

--- a/src/Preview.jsx
+++ b/src/Preview.jsx
@@ -4,6 +4,12 @@ import Colr from 'colr';
 const colr = new Colr();
 
 export default class Preview extends React.Component {
+  onChange(e) {
+    const value = e.target.value;
+    const color = colr.fromHex(value);
+    this.props.onChange(color.toHsvObject());
+  }
+
   getPrefixCls() {
     return this.props.rootPrefixCls + '-preview';
   }
@@ -12,8 +18,10 @@ export default class Preview extends React.Component {
     const prefixCls = this.getPrefixCls();
     const hex = colr.fromHsvObject(this.props.hsv).toHex();
     return (
-      <div className={prefixCls}>
-        <span style={{backgroundColor: hex, opacity: this.props.alpha / 100}}></span>
+      <div className={prefixCls}
+        style={{backgroundColor: hex, opacity: this.props.alpha / 100}}
+      >
+        <input type="color" value={hex} onChange={this.onChange.bind(this)}/>
       </div>
     );
   }
@@ -23,4 +31,5 @@ Preview.propTypes = {
   rootPrefixCls: React.PropTypes.string,
   hsv: React.PropTypes.object,
   alpha: React.PropTypes.number,
+  onChange: React.PropTypes.func,
 };


### PR DESCRIPTION
- Remove store, use prop.mode to set which color mode need.
- Add `<input type=color>` for prevew, so we can use system color picker select color from every where.