### PR TITLE
refactor: Upgrade utils and replace useMergedState

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@ant-design/fast-color": "^3.0.0",
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.3.0",
     "classnames": "^2.2.6"
   },
   "devDependencies": {

--- a/src/hooks/useColorState.ts
+++ b/src/hooks/useColorState.ts
@@ -1,4 +1,4 @@
-import { useMergedState } from '@rc-component/util';
+import { useControlledState } from '@rc-component/util';
 import { useMemo } from 'react';
 import type { Color } from '../color';
 import type { ColorGenInput } from '../interface';
@@ -10,7 +10,7 @@ const useColorState = (
   defaultValue: ColorValue,
   value?: ColorValue,
 ): [Color, React.Dispatch<React.SetStateAction<Color>>] => {
-  const [mergedValue, setValue] = useMergedState(defaultValue, { value });
+  const [mergedValue, setValue] = useControlledState(defaultValue, value);
 
   const color = useMemo(() => generateColor(mergedValue), [mergedValue]);
 


### PR DESCRIPTION
关联issue：https://github.com/ant-design/ant-design/issues/54854
替换 useMergedState 为 useControlledState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 杂务
  - 将依赖 @rc-component/util 升级至 1.3.0，包含上游修复与优化，提升稳定性与兼容性，无需用户操作。

- 重构
  - 调整内部颜色状态管理实现，改用受控状态钩子以简化逻辑、提升一致性并减少边界问题；对外接口与功能无变化，无需迁移。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->